### PR TITLE
Ticket #23 - View All User Profiles

### DIFF
--- a/Tabloid/Controllers/UserProfileController.cs
+++ b/Tabloid/Controllers/UserProfileController.cs
@@ -17,6 +17,12 @@ namespace Tabloid.Controllers
             _userRepository = userRepository;
         }
 
+        [HttpGet]
+        public IActionResult Get()
+        {
+            return Ok(_userRepository.getAllProfiles());
+        }
+
         [HttpGet("GetByEmail")]
         public IActionResult GetByEmail(string email)
         {

--- a/Tabloid/Repositories/IUserRepository.cs
+++ b/Tabloid/Repositories/IUserRepository.cs
@@ -1,9 +1,12 @@
-﻿using Tabloid.Models;
+﻿using System.Collections.Generic;
+using Tabloid.Models;
 
 namespace Tabloid.Repositories
 {
     public interface IUserRepository
     {
+        List<UserProfile> getAllProfiles();
+
         //void Add(UserProfile userProfile);
         UserProfile GetByEmail(string email);
     }

--- a/Tabloid/Repositories/UserRepository.cs
+++ b/Tabloid/Repositories/UserRepository.cs
@@ -23,7 +23,7 @@ namespace Tabloid.Repositories
                                ut.Name AS UserTypeName
                           FROM UserProfile up
                                LEFT JOIN UserType ut on up.UserTypeId = ut.Id
-                         WHERE Email = @email";
+                           ORDER BY up.DisplayName";
 
                     var reader = cmd.ExecuteReader();
                     var profile = new List<UserProfile>();

--- a/Tabloid/Repositories/UserRepository.cs
+++ b/Tabloid/Repositories/UserRepository.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Configuration;
+using System.Collections.Generic;
 using Tabloid.Models;
 using Tabloid.Utils;
 
@@ -8,6 +9,49 @@ namespace Tabloid.Repositories
     public class UserRepository : BaseRepository, IUserRepository
     {
         public UserRepository(IConfiguration configuration) : base(configuration) { }
+
+        public List<UserProfile> getAllProfiles()
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                        SELECT up.Id, up.FirstName, up.LastName, up.DisplayName, 
+                               up.Email, up.CreateDateTime, up.ImageLocation, up.UserTypeId,
+                               ut.Name AS UserTypeName
+                          FROM UserProfile up
+                               LEFT JOIN UserType ut on up.UserTypeId = ut.Id
+                         WHERE Email = @email";
+
+                    var reader = cmd.ExecuteReader();
+                    var profile = new List<UserProfile>();
+                    while (reader.Read())
+                    {
+                        profile.Add(new UserProfile()
+                        {
+                            Id = DbUtils.GetInt(reader, "Id"),
+                            FirstName = DbUtils.GetString(reader, "FirstName"),
+                            LastName = DbUtils.GetString(reader, "LastName"),
+                            DisplayName = DbUtils.GetString(reader, "DisplayName"),
+                            Email = DbUtils.GetString(reader, "Email"),
+                            CreateDateTime = DbUtils.GetDateTime(reader, "CreateDateTime"),
+                            ImageLocation = DbUtils.GetString(reader, "ImageLocation"),
+                            UserTypeId = DbUtils.GetInt(reader, "UserTypeId"),
+                            UserType = new UserType()
+                            {
+                                Id = DbUtils.GetInt(reader, "UserTypeId"),
+                                Name = DbUtils.GetString(reader, "UserTypeName"),
+                            }
+                        });
+                    }
+                    reader.Close();
+                    return profile;
+                }
+            }
+        }
+
 
         public UserProfile GetByEmail(string email)
         {

--- a/Tabloid/client/src/Managers/UserProfileManager.js
+++ b/Tabloid/client/src/Managers/UserProfileManager.js
@@ -1,9 +1,9 @@
-
-
-
-
-
   const apiUrl = "https://localhost:5001";
+
+  export const getAllProfiles = () => {
+    return fetch (`${apiUrl}/api/userprofile`)
+    .then((response) => response.json())
+};
 
   export const login = (userObject) => {
     return fetch(`${apiUrl}/api/userprofile/getbyemail?email=${userObject.email}`)

--- a/Tabloid/client/src/components/ApplicationViews.js
+++ b/Tabloid/client/src/components/ApplicationViews.js
@@ -10,8 +10,8 @@ import CategoryList from "./CategoryList";
 
 
 
-import Hello from "./Hello";
 import TagList from "./TagList";
+import ProfileList from "./UserProfiles/UserProfileList";
 
 
 export default function ApplicationViews() {
@@ -22,6 +22,7 @@ export default function ApplicationViews() {
        <Route path="/post" element= {<PostList/>} />
         <Route path="/category" element={<CategoryList />} />
         <Route path="/TagManagement" element={<TagList />} />
+        <Route path= "/profiles" element={<ProfileList />} />
       </Routes>
    );
  

--- a/Tabloid/client/src/components/Header.js
+++ b/Tabloid/client/src/components/Header.js
@@ -16,8 +16,10 @@ export default function Header({isLoggedIn, setIsLoggedIn}) {
   const toggle = () => setIsOpen(!isOpen);
 
   return (
-    <div>
+  
+      <>
       <Navbar color="light" light expand="md">
+            
         <NavbarBrand tag={RRNavLink} to="/">Tabloid</NavbarBrand>
         <NavbarToggler onClick={toggle} />
         <Collapse isOpen={isOpen} navbar>
@@ -36,16 +38,15 @@ export default function Header({isLoggedIn, setIsLoggedIn}) {
 
                 <NavLink tag={RRNavLink} to="/post">Post Management</NavLink>
               </NavItem>
-
+              <NavItem>
               <NavLink tag={RRNavLink} to="/TagManagement">Tag Management</NavLink>
             </NavItem>
-
               </>
-              
             }
-            </Nav>
+          </Nav>         
          
-
+          
+          
           <Nav navbar>
             {isLoggedIn &&
               <>
@@ -74,8 +75,8 @@ export default function Header({isLoggedIn, setIsLoggedIn}) {
               </>
             }
           </Nav>
-        </Collapse>
+       </Collapse>
       </Navbar>
-    </div>
-  );
+    </>
+)
 }

--- a/Tabloid/client/src/components/Header.js
+++ b/Tabloid/client/src/components/Header.js
@@ -34,12 +34,17 @@ export default function Header({isLoggedIn, setIsLoggedIn}) {
                <NavItem>
                 <NavLink tag={RRNavLink} to="/category">Category Management</NavLink>
               </NavItem>
+              
               <NavItem>
-
                 <NavLink tag={RRNavLink} to="/post">Post Management</NavLink>
               </NavItem>
+
               <NavItem>
               <NavLink tag={RRNavLink} to="/TagManagement">Tag Management</NavLink>
+            </NavItem>
+
+            <NavItem>
+              <NavLink tag={RRNavLink} to="/profiles">User Profiles</NavLink>
             </NavItem>
               </>
             }

--- a/Tabloid/client/src/components/UserProfiles/UserProfileList.js
+++ b/Tabloid/client/src/components/UserProfiles/UserProfileList.js
@@ -1,0 +1,36 @@
+import React, {useEffect, useState} from "react";
+import { getAllProfiles } from "../../Managers/UserProfileManager";
+import UserProfile from "./Userprofile";
+
+const ProfileList = () => {
+const [profile, setProfile] = useState([])
+
+const getProfiles = () => {
+    getAllProfiles().then((allProfiles) => setProfile(allProfiles))
+}
+
+useEffect(() => {
+    getProfiles()
+}, [])
+
+return (
+    <>
+      <div className="container">
+        <div className="row justify-content-center">
+            <div className="card-column">
+
+          {profile.map((profile) => (
+              <tr>
+                <td >
+                  <UserProfile key={profile.id} profile={profile} />
+                </td>
+                  </tr>
+              ))}
+              </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default ProfileList;

--- a/Tabloid/client/src/components/UserProfiles/Userprofile.js
+++ b/Tabloid/client/src/components/UserProfiles/Userprofile.js
@@ -1,0 +1,26 @@
+import React from "react";
+import { CardTitle } from "reactstrap";
+import Card from "reactstrap/lib/Card";
+import CardBody from "reactstrap/lib/CardBody";
+import CardSubtitle from "reactstrap/lib/CardSubtitle";
+import CardText from "reactstrap/lib/CardText";
+import Button from "reactstrap/lib/Button";
+
+const UserProfile = ({profile}) => {
+    return (
+        <>
+            <div style={{marginBottom: "2vw"}}>
+      <Card>
+        <CardBody>
+          <CardTitle>{profile.fullName}</CardTitle>
+          <CardSubtitle>{profile.displayName}</CardSubtitle>
+          <CardText>{profile.userType.name}</CardText>
+          <a href="/profiles">Details</a>
+        </CardBody>
+      </Card>
+    </div>
+        </>
+    )
+}
+
+export default UserProfile

--- a/Tabloid/client/src/components/UserProfiles/Userprofile.js
+++ b/Tabloid/client/src/components/UserProfiles/Userprofile.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { CardTitle } from "reactstrap";
+import { CardTitle, Row, Table } from "reactstrap";
 import Card from "reactstrap/lib/Card";
 import CardBody from "reactstrap/lib/CardBody";
 import CardSubtitle from "reactstrap/lib/CardSubtitle";
@@ -12,8 +12,8 @@ const UserProfile = ({profile}) => {
             <div style={{marginBottom: "2vw"}}>
       <Card>
         <CardBody>
-          <CardTitle>{profile.fullName}</CardTitle>
-          <CardSubtitle>{profile.displayName}</CardSubtitle>
+          <CardTitle><h4>{profile.displayName}</h4></CardTitle>
+          <CardSubtitle>{profile.fullName}</CardSubtitle>
           <CardText>{profile.userType.name}</CardText>
           <a href="/profiles">Details</a>
         </CardBody>


### PR DESCRIPTION
# Description
This PR is for [Ticket #23](https://trello.com/c/oIfmok6u/23-23-view-all-user-profiles), which should allow an admin to view all profiles by selecting the `User Profiles` option in the header menu.

> Note: User type differentiation/User privilege restriction has yet to be added.

# Testing Instructions
1. Commit or stash whatever you're currently working on
2. Git fetch --all
3. Git checkout ac-viewAllUserProfiles
4. If you don't see the most recent version of my files, git pull origin ac-viewAllUserProfiles
5.  If you need to create the Tabloid database, [use this file to do so](https://github.com/NewForce-Cohort-6/tabloidfullstack-cranberry-sauce/blob/main/SQL/01_Tabloid_Create_DB.sql)
6. If you don't have the Tabloid seed data, [use this file to get it
](https://github.com/NewForce-Cohort-6/tabloidfullstack-cranberry-sauce/blob/main/SQL/02_Tabloid_Seed_Data.sql)
7. Execute Tabloid from inside of Visual Studio
![Tabloid](https://user-images.githubusercontent.com/106983427/202474349-d57baf9b-323c-4406-b75a-d8f99a886603.png)
8.  Run NPM Start from inside of the Tabloid client folder
![client](https://user-images.githubusercontent.com/106983427/202473962-42d0b50f-1420-4b34-a522-464dc9fc11d5.png)
9. Login using an email that you know is there and works for you (example: foo@bar.com from seed data)
10. Once logged-in, select `User Profiles` from the navigation bar
11. You'll be redirected to  `'/profiles'` and you should see the user's `full name`, `display name`, and `type`. 

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
